### PR TITLE
3.2-UI-LaTeXConversionImprovement

### DIFF
--- a/CAS.Core/EquationParsing/ASTNode.cs
+++ b/CAS.Core/EquationParsing/ASTNode.cs
@@ -839,8 +839,21 @@ namespace CAS.Core.EquationParsing
       }
       if (IsFunction())
       {
-        var args = string.Join(", ", Children.Select(c => c.ToLatex()));
-        return $"{Token.Type.stringValue}\\left({args}\\right)";
+        if (Kind() == "nroot")
+        {
+          var inside = Children[0].ToLatex();
+          var degree = Children[1].ToLatex();
+
+          if (degree == "2")
+            return $"\\sqrt{{{inside}}}";
+          else
+            return $"\\sqrt[{degree}]{{{inside}}}";
+        }
+        else
+        {
+          var args = string.Join(", ", Children.Select(c => c.ToLatex()));
+          return $"{Token.Type.stringValue}\\left({args}\\right)";
+        }
       }
       if (Token.Type is Operator op)
       {

--- a/CAS.Core/Simplifier.cs
+++ b/CAS.Core/Simplifier.cs
@@ -75,14 +75,112 @@ namespace CAS.Core
     }
 
     /// <summary>
-    /// Will remove the negative exponent in a tree to make it ready for printing in LaTeX.
+    /// Will format the tree to make it ready for printing in LaTeX.
+    /// Converts negative exponents to divisions and rational exponents to roots if possible.
     /// </summary>
     /// <remarks>This should be applied after an <see cref="Simplifier.AutomaticSimplify(ASTNode, bool)"/> 
     /// since it converts division to negative exponents.</remarks>
     /// <param name="root">The root of the tree</param>
     public void PostFormatTree(ASTNode root)
     {
-      
+      // Format this node
+      // Firstly: Convert negative exponents to divisions
+      if (root.Kind() == "*")
+      {
+        // Find all the negative exponent children and transform the product to a division
+        List<ASTNode> numeratorChildren = new List<ASTNode>();
+        List<ASTNode> denominatorChildren = new List<ASTNode>();
+
+        foreach (var child in root.Children)
+        {
+          if (child.Kind() == "^")
+          {
+            var expNode = child.Exponent();
+            var expValue = expNode.Const().EvaluateAsDouble();
+
+            if (expValue < 0)
+            {
+              if (Math.Abs(expValue + 1) < EPSILON)
+              {
+                // Exponent is one
+                denominatorChildren.Add(child.Children[0]);
+              }
+              else
+              {
+                denominatorChildren.Add(new ASTNode(Token.Operator("^"), new List<ASTNode> {
+                  child.Children[0],
+                  AutomaticSimplify(new ASTNode(Token.Operator("*"), new List<ASTNode> { new ASTNode(Token.Integer("-1")), expNode }))
+                }));
+              }
+            }
+            else
+              numeratorChildren.Add(child);
+          }
+          else
+            numeratorChildren.Add(child);
+        }
+
+        if (denominatorChildren.Count != 0)
+        {
+          root.Token = Token.Operator("/");
+          root.Children = new List<ASTNode>();
+          if (numeratorChildren.Count == 0)
+            root.Children.Add(new ASTNode(Token.Integer("1")));
+          else if (numeratorChildren.Count == 1)
+            root.Children.Add(numeratorChildren[0]);
+          else
+            root.Children.Add(new ASTNode(Token.Operator("*"), numeratorChildren));
+
+          if (denominatorChildren.Count == 1)
+            root.Children.Add(denominatorChildren[0]);
+          else
+            root.Children.Add(new ASTNode(Token.Operator("*"), denominatorChildren));
+        }
+      }
+      else if (root.Kind() == "^")
+      {
+        var expNode = root.Exponent();
+        var expValue = expNode.Const().EvaluateAsDouble();
+
+        if (expValue < 0)
+        {
+          if (Math.Abs(expValue + 1) < EPSILON && expNode.IsConstant())
+          {
+            // Exponent is one
+            root.Token = Token.Operator("/");
+            root.Children[1] = root.Children[0];
+            root.Children[0] = new ASTNode(Token.Integer("1"));
+          }
+          else
+          {
+            root.Token = Token.Operator("/");
+            root.Children[1] = new ASTNode(Token.Operator("^"), new List<ASTNode> {
+              root.Children[0],
+              AutomaticSimplify(new ASTNode(Token.Operator("*"), new List<ASTNode> { new ASTNode(Token.Integer("-1")), expNode }))
+            });
+            root.Children[0] = new ASTNode(Token.Integer("1"));
+          }
+        }
+      }
+
+      // Secondly: Converts rational exponents of the form 1/n to the nroot function
+      if (root.Kind() == "^")
+      {
+        var expNode = root.Exponent();
+        if (expNode.Token.Type is Fraction)
+        {
+          var numDenum = Calculator.GetNumAndDenum(expNode);
+          if (numDenum[0] == 1)
+          {
+            root.Token = Token.Function("nroot");
+            root.Children[1] = new ASTNode(Token.Integer(numDenum[1].ToString()));
+          }
+        }  
+      }
+
+      // Format the children
+      foreach (var child in root.Children)
+        PostFormatTree(child);
     }
 
     /// <summary>
@@ -157,7 +255,7 @@ namespace CAS.Core
       if (input.Token.Type is Number || input.Token.Type is Variable)
         result = input;
       else if (input.Token.Type is Fraction)
-        result =  SimplifyRationalNumber(input);
+        result = SimplifyRationalNumber(input);
       else
       {
         // Simplify the nodes recursively
@@ -502,7 +600,7 @@ namespace CAS.Core
         var mMinusN = new ASTNode(Token.Integer((m - n).ToString()));
         q = AutomaticSimplify(new ASTNode(Token.Operator("+"), new List<ASTNode>
         {
-          q, new ASTNode(Token.Operator("*"), new List<ASTNode>{ 
+          q, new ASTNode(Token.Operator("*"), new List<ASTNode>{
             s, new ASTNode(Token.Operator("^"), new List<ASTNode> {
               new ASTNode(x), new ASTNode(mMinusN) }) })
         }), false);
@@ -1209,7 +1307,7 @@ namespace CAS.Core
       if (root.IsPower())
         ExpandPower(root);
     }
-    
+
     private void ExpandProduct(ASTNode root)
     {
       // Return if a unary product
@@ -1396,9 +1494,9 @@ namespace CAS.Core
         return [productPullOut, newPoly];
       }
       else
-        return [ null, poly ];
+        return [null, poly];
     }
-    
+
     private List<ASTNode> Polynomial2ndDegreeFactorization(ASTNode poly, ASTNode x)
     {
       ASTNode a = new ASTNode(Token.Integer("0"));
@@ -1431,7 +1529,7 @@ namespace CAS.Core
           throw new ArgumentException("'poly' is not a 2nd degree polynomial.");
       }
 
-      var discriminant = AutomaticSimplify(new ASTNode(Token.Operator("-"), new List<ASTNode> 
+      var discriminant = AutomaticSimplify(new ASTNode(Token.Operator("-"), new List<ASTNode>
       {
         new ASTNode(Token.Operator("^"), new List<ASTNode> {b, new ASTNode(Token.Integer("2"))}),
         new ASTNode(Token.Operator("*"), new List<ASTNode>

--- a/CAS.Desktop/Views/MainPage.xaml.cs
+++ b/CAS.Desktop/Views/MainPage.xaml.cs
@@ -465,6 +465,7 @@ namespace CAS.Desktop.Views
 
           simplifier.FormatTree(tree);
           var simplifiedTree = simplifier.AutomaticSimplify(tree);
+          simplifier.PostFormatTree(simplifiedTree);
           resultLatex = simplifiedTree.ToLatex();
         }
         catch (Exception ex)
@@ -484,6 +485,7 @@ namespace CAS.Desktop.Views
 
           simplifier.FormatTree(tree);
           var simplifiedTree = simplifier.Expand(tree);
+          simplifier.PostFormatTree(simplifiedTree);
           resultLatex = simplifiedTree.ToLatex();
         }
         catch (Exception ex)
@@ -539,6 +541,7 @@ namespace CAS.Desktop.Views
             });
           }
 
+          simplifier.PostFormatTree(finalResulTree);
           resultLatex = finalResulTree.ToLatex();
         }
         catch (Exception ex)


### PR DESCRIPTION
Added the Simplifier.PostFormatTree(ASTNode root) to format a tree after apllying AutomaticSimplifications to it. Includes:
- Converting negative exponents to divisions
- Converting rational exponents of the form (1/n) to nth root symbols in LaTeX using the intermediate "nroot" function.